### PR TITLE
Minor tweak to README, missing "fmt" import

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Below is a simple example, for a full example [see here](https://github.com/go-p
 package main
 
 import (
+        "fmt"
 	"net/http"
 
 	"github.com/go-playground/lars"


### PR DESCRIPTION
Line 26 of the example uses fmt, but it wasn't in the import list.