### PR TITLE
doc: fix install command and use the right markdown flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,8 @@ Key & Unique Features
 Installation
 -----------
 
-Use go get 
-
-```go
-go -u get github.com/go-playground/lars
+```shell
+go get -u github.com/go-playground/lars
 ```
 
 Usage


### PR DESCRIPTION
In #11 I inverted the `-u` flag in the `go get` command, it should be `go get -u` not `go -u get`. Sorry about that.

Also, I changed to the markdown flag from `go` to `shell`.